### PR TITLE
Fix Health Check Config Value

### DIFF
--- a/config.yml.template
+++ b/config.yml.template
@@ -22,7 +22,7 @@ EDEX:
     cooldown: 60                                                 # The wait time (in seconds) after EDEX services are started by the script.
     auto_restart: False                                          # Set to True to have the script attempt to restart services if they crash.
     health_check_url: http://127.0.0.1:12576/sensor/inv
-    health_check_enable: True
+    health_check_enabled: True
 
 EMAIL: # Used for email notifications of errors. Requires a valid SMTP server to work.
     enabled: False


### PR DESCRIPTION
Fix the following error:

Traceback (most recent call last):
  File "ingest.py", line 799, in <module>
    perform = Task(args)
  File "ingest.py", line 165, in __init__
    'health_check_enabled': EDEX['health_check_enabled'],
KeyError: 'health_check_enabled'
