### PR TITLE
Fixed error in ingest dir option where files where not found

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -335,7 +335,7 @@ class Task(object):
         if not csv_dir:
             self.logger.error("No valid directory specified.")
             return False
-        csv_files = [os.path.abspath(f) for f in os.listdir(csv_dir) if f.endswith(".csv")]
+        csv_files = [csv_dir + '/' + f for f in os.listdir(csv_dir) if f.endswith(".csv")]
         if not csv_files:
             self.logger.error("No CSV files in specified directory.")
 


### PR DESCRIPTION
Using from_dir option would result in csv files not being found.  This change fixes that error by appending the found file names to the directory of the csv files. 